### PR TITLE
add(DEVOPS-1259): secrets support to docker actions

### DIFF
--- a/actions/ci-dockerized-app-build-push/action.yml
+++ b/actions/ci-dockerized-app-build-push/action.yml
@@ -61,6 +61,9 @@ inputs:
     description: 'The key to store/retrieve the cache'
     required: false
     default: ''
+  secrets:
+    description: "List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)"
+    required: false
 
 outputs:
   imageid:
@@ -126,7 +129,7 @@ runs:
       username: "oauth2accesstoken"
       password: "${{ steps.google-auth.outputs.access_token }}"
   - name: Build and push Docker images
-    uses: Zilliqa/gh-actions-workflows/actions/docker-build-push@main
+    uses: Zilliqa/gh-actions-workflows/actions/docker-build-push@DEVOPS-1259
     id: build-push
     with:
       file: ${{ inputs.file }}
@@ -138,3 +141,4 @@ runs:
       tags: ${{ steps.image-tags.outputs.tags }}
       cache-from: ${{ steps.docker-cache.outputs.cachefrom }}
       cache-to: ${{ steps.docker-cache.outputs.cacheto }}
+      secrets: ${{ inputs.secrets }}

--- a/actions/ci-dockerized-app-build-push/action.yml
+++ b/actions/ci-dockerized-app-build-push/action.yml
@@ -129,7 +129,7 @@ runs:
       username: "oauth2accesstoken"
       password: "${{ steps.google-auth.outputs.access_token }}"
   - name: Build and push Docker images
-    uses: Zilliqa/gh-actions-workflows/actions/docker-build-push@DEVOPS-1259
+    uses: Zilliqa/gh-actions-workflows/actions/docker-build-push@main
     id: build-push
     with:
       file: ${{ inputs.file }}

--- a/actions/docker-build-push/action.yml
+++ b/actions/docker-build-push/action.yml
@@ -32,6 +32,9 @@ inputs:
   cache-to:
     description: 'The username to access the registry'
     required: false
+  secrets:
+    description: "List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)"
+    required: false
 
 outputs:
   imageid:
@@ -71,3 +74,4 @@ runs:
       tags: ${{ inputs.tags }}
       cache-from: ${{ inputs.cache-from }}
       cache-to: ${{ inputs.cache-to }}
+      secrets: ${{ inputs.secrets }}


### PR DESCRIPTION
... allows to pass generic secrets to dockerized build. Useful to manage the build which requires the pull from private repositories from inside docker containers