### PR TITLE
feat: DEVOPS-1287 cache registry for prod pipelines

### DIFF
--- a/actions/ci-dockerized-app-build-push/action.yml
+++ b/actions/ci-dockerized-app-build-push/action.yml
@@ -87,7 +87,7 @@ runs:
   using: "composite"
   steps:
   - name: Docker cache
-    uses: Zilliqa/gh-actions-workflows/actions/docker-cache@devops-1287
+    uses: Zilliqa/gh-actions-workflows/actions/docker-cache@v2
     id: docker-cache
     with:
       backend: ${{ inputs.cache-backend }}

--- a/actions/ci-dockerized-app-build-push/action.yml
+++ b/actions/ci-dockerized-app-build-push/action.yml
@@ -87,7 +87,7 @@ runs:
   using: "composite"
   steps:
   - name: Docker cache
-    uses: Zilliqa/gh-actions-workflows/actions/docker-cache@v2
+    uses: Zilliqa/gh-actions-workflows/actions/docker-cache@devops-1287
     id: docker-cache
     with:
       backend: ${{ inputs.cache-backend }}

--- a/actions/docker-cache/action.yml
+++ b/actions/docker-cache/action.yml
@@ -25,9 +25,8 @@ outputs:
 runs:
   using: "composite"
   steps:
-  - name: Set cache for branches
-    id: cache-branches
-    if: startsWith(github.ref, 'refs/heads/v')
+  - name: Set cache
+    id: cache
     run: |
       if [ "${{ inputs.key }}" = "" ]; then
         echo "cachefrom=" >> $GITHUB_OUTPUT
@@ -35,24 +34,12 @@ runs:
       elif [ "${{ inputs.backend }}" = "gha" ]; then
         echo "cachefrom=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }},mode=max" >> $GITHUB_OUTPUT
-      elif [ "${{ inputs.backend }}" = "registry" ]; then
+      elif [ "${{ inputs.backend }}" = "registry"  && "${{ github.ref }}" == refs/heads/* ]; then
         export SCOPE=$(echo -n "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | sed 's/[^[:alnum:]._-]//g')
         echo "cachefrom=type=registry,ref=${{ inputs.key }}:$SCOPE" >> $GITHUB_OUTPUT
         echo "cachefromfallback=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=registry,ref=${{ inputs.key }}:$SCOPE,mode=max" >> $GITHUB_OUTPUT
-      fi
-    shell: bash
-  - name: Set cache for tags
-    id: cache-tags
-    if: startsWith(github.ref, 'refs/tags/v')
-    run: |
-      if [ "${{ inputs.key }}" = "" ]; then
-        echo "cachefrom=" >> $GITHUB_OUTPUT
-        echo "cacheto=" >> $GITHUB_OUTPUT
-      elif [ "${{ inputs.backend }}" = "gha" ]; then
-        echo "cachefrom=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }}" >> $GITHUB_OUTPUT
-        echo "cacheto=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }},mode=max" >> $GITHUB_OUTPUT
-      elif [ "${{ inputs.backend }}" = "registry" ]; then
+      elif [ "${{ inputs.backend }}" = "registry" && "${{ github.ref }}" == refs/tags/* ]; then
         echo "cachefrom=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }},mode=max" >> $GITHUB_OUTPUT
       fi

--- a/actions/docker-cache/action.yml
+++ b/actions/docker-cache/action.yml
@@ -25,10 +25,9 @@ outputs:
 runs:
   using: "composite"
   steps:
-  - name: Set cache
-    id: cache
-    env:
-      BRANCH_OR_TAG_NAME: ${{ github.head_ref || github.ref_name }}
+  - name: Set cache for branches
+    id: cache-branches
+    if: startsWith(github.ref, 'refs/heads/v')
     run: |
       if [ "${{ inputs.key }}" = "" ]; then
         echo "cachefrom=" >> $GITHUB_OUTPUT
@@ -37,9 +36,24 @@ runs:
         echo "cachefrom=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }},mode=max" >> $GITHUB_OUTPUT
       elif [ "${{ inputs.backend }}" = "registry" ]; then
-        export SCOPE=$(echo -n "${{ env.BRANCH_OR_TAG_NAME }}" | sed 's/[^[:alnum:]._-]//g')
+        export SCOPE=$(echo -n "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | sed 's/[^[:alnum:]._-]//g')
         echo "cachefrom=type=registry,ref=${{ inputs.key }}:$SCOPE" >> $GITHUB_OUTPUT
         echo "cachefromfallback=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=registry,ref=${{ inputs.key }}:$SCOPE,mode=max" >> $GITHUB_OUTPUT
+      fi
+    shell: bash
+  - name: Set cache for tags
+    id: cache-tags
+    if: startsWith(github.ref, 'refs/tags/v')
+    run: |
+      if [ "${{ inputs.key }}" = "" ]; then
+        echo "cachefrom=" >> $GITHUB_OUTPUT
+        echo "cacheto=" >> $GITHUB_OUTPUT
+      elif [ "${{ inputs.backend }}" = "gha" ]; then
+        echo "cachefrom=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }}" >> $GITHUB_OUTPUT
+        echo "cacheto=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }},mode=max" >> $GITHUB_OUTPUT
+      elif [ "${{ inputs.backend }}" = "registry" ]; then
+        echo "cachefrom=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
+        echo "cacheto=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }},mode=max" >> $GITHUB_OUTPUT
       fi
     shell: bash

--- a/actions/docker-cache/action.yml
+++ b/actions/docker-cache/action.yml
@@ -34,12 +34,12 @@ runs:
       elif [ "${{ inputs.backend }}" = "gha" ]; then
         echo "cachefrom=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }},mode=max" >> $GITHUB_OUTPUT
-      elif [ "${{ inputs.backend }}" = "registry" ] && [[ "${{ github.ref }}" == refs/heads/* ]]; then
+      elif [ "${{ inputs.backend }}" = "registry" ] && ([ github.event_name == "pull_request" ] || [ github.event_name == "push" ]); then
         export SCOPE=$(echo -n "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | sed 's/[^[:alnum:]._-]//g')
         echo "cachefrom=type=registry,ref=${{ inputs.key }}:$SCOPE" >> $GITHUB_OUTPUT
         echo "cachefromfallback=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=registry,ref=${{ inputs.key }}:$SCOPE,mode=max" >> $GITHUB_OUTPUT
-      elif [ "${{ inputs.backend }}" = "registry" ] && [[ "${{ github.ref }}" == refs/tags/* ]]; then
+      elif [ "${{ inputs.backend }}" = "registry" ] && [ github.event_name == "release" ]; then
         echo "cachefrom=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }},mode=max" >> $GITHUB_OUTPUT
       fi

--- a/actions/docker-cache/action.yml
+++ b/actions/docker-cache/action.yml
@@ -34,12 +34,12 @@ runs:
       elif [ "${{ inputs.backend }}" = "gha" ]; then
         echo "cachefrom=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }},mode=max" >> $GITHUB_OUTPUT
-      elif [ "${{ inputs.backend }}" = "registry"  && "${{ github.ref }}" == refs/heads/* ]; then
+      elif [ "${{ inputs.backend }}" = "registry" ] && [ "${{ github.ref }}" == refs/heads/* ]; then
         export SCOPE=$(echo -n "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | sed 's/[^[:alnum:]._-]//g')
         echo "cachefrom=type=registry,ref=${{ inputs.key }}:$SCOPE" >> $GITHUB_OUTPUT
         echo "cachefromfallback=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=registry,ref=${{ inputs.key }}:$SCOPE,mode=max" >> $GITHUB_OUTPUT
-      elif [ "${{ inputs.backend }}" = "registry" && "${{ github.ref }}" == refs/tags/* ]; then
+      elif [ "${{ inputs.backend }}" = "registry" ] && [ "${{ github.ref }}" == refs/tags/* ]; then
         echo "cachefrom=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }},mode=max" >> $GITHUB_OUTPUT
       fi

--- a/actions/docker-cache/action.yml
+++ b/actions/docker-cache/action.yml
@@ -37,7 +37,7 @@ runs:
         echo "cachefrom=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }},mode=max" >> $GITHUB_OUTPUT
       elif [ "${{ inputs.backend }}" = "registry" ]; then
-        export SCOPE=$(echo -n "${{ BRANCH_OR_TAG_NAME }}" | sed 's/[^[:alnum:]._-]//g')
+        export SCOPE=$(echo -n "${{ env.BRANCH_OR_TAG_NAME }}" | sed 's/[^[:alnum:]._-]//g')
         echo "cachefrom=type=registry,ref=${{ inputs.key }}:$SCOPE" >> $GITHUB_OUTPUT
         echo "cachefromfallback=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=registry,ref=${{ inputs.key }}:$SCOPE,mode=max" >> $GITHUB_OUTPUT

--- a/actions/docker-cache/action.yml
+++ b/actions/docker-cache/action.yml
@@ -34,12 +34,12 @@ runs:
       elif [ "${{ inputs.backend }}" = "gha" ]; then
         echo "cachefrom=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }},mode=max" >> $GITHUB_OUTPUT
-      elif [ "${{ inputs.backend }}" = "registry" ] && [ "${{ github.ref }}" == refs/heads/* ]; then
+      elif [ "${{ inputs.backend }}" = "registry" ] && [[ "${{ github.ref }}" == refs/heads/* ]]; then
         export SCOPE=$(echo -n "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | sed 's/[^[:alnum:]._-]//g')
         echo "cachefrom=type=registry,ref=${{ inputs.key }}:$SCOPE" >> $GITHUB_OUTPUT
         echo "cachefromfallback=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=registry,ref=${{ inputs.key }}:$SCOPE,mode=max" >> $GITHUB_OUTPUT
-      elif [ "${{ inputs.backend }}" = "registry" ] && [ "${{ github.ref }}" == refs/tags/* ]; then
+      elif [ "${{ inputs.backend }}" = "registry" ] && [[ "${{ github.ref }}" == refs/tags/* ]]; then
         echo "cachefrom=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }},mode=max" >> $GITHUB_OUTPUT
       fi

--- a/actions/docker-cache/action.yml
+++ b/actions/docker-cache/action.yml
@@ -27,6 +27,8 @@ runs:
   steps:
   - name: Set cache
     id: cache
+    env:
+      BRANCH_OR_TAG_NAME: ${{ github.head_ref || github.ref_name }}
     run: |
       if [ "${{ inputs.key }}" = "" ]; then
         echo "cachefrom=" >> $GITHUB_OUTPUT
@@ -35,7 +37,7 @@ runs:
         echo "cachefrom=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=gha,scope=${{ github.event.repository.name }}-${{ inputs.key }},mode=max" >> $GITHUB_OUTPUT
       elif [ "${{ inputs.backend }}" = "registry" ]; then
-        export SCOPE=$(echo -n "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | sed 's/[^[:alnum:]._-]//g')
+        export SCOPE=$(echo -n "${{ BRANCH_OR_TAG_NAME }}" | sed 's/[^[:alnum:]._-]//g')
         echo "cachefrom=type=registry,ref=${{ inputs.key }}:$SCOPE" >> $GITHUB_OUTPUT
         echo "cachefromfallback=type=registry,ref=${{ inputs.key }}:${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
         echo "cacheto=type=registry,ref=${{ inputs.key }}:$SCOPE,mode=max" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Condition to force tag cache to go and push always to main tag.

Generated chunk from a tag:

`/usr/bin/docker buildx build --build-arg DEPLOY_ENV=prd --cache-from type=registry,ref=asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private/scamcheck-cache:main --cache-to type=registry,ref=asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private/scamcheck-cache:main,mode=max --iidfile /home/runner/work/_temp/docker-actions-toolkit-qeCo0y/iidfile --provenance mode=min,inline-only=true,builder-id=https://github.com/Zilliqa/zilliqa-internal/actions/runs/8248991661 --tag asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private/scamcheck:v0.0.99 --metadata-file /home/runner/work/_temp/docker-actions-toolkit-qeCo0y/metadata-file --pull --push products/scamcheck`