### PR TITLE
feat: DEVOPS-228 gate registry auth on push to fix WIF rejection on non-default branches

### DIFF
--- a/actions/ci-dockerized-app-build-push/action.yml
+++ b/actions/ci-dockerized-app-build-push/action.yml
@@ -111,7 +111,7 @@ runs:
 
   - name: Login to Dockerhub
     uses: docker/login-action@v4
-    if: ${{ inputs.registry-username != '' && inputs.registry-password != '' }}
+    if: ${{ inputs.push == 'true' && inputs.registry-username != '' && inputs.registry-password != '' }}
     with:
       username: ${{ inputs.registry-username }}
       password: ${{ inputs.registry-password }}
@@ -119,7 +119,7 @@ runs:
   - name: Configure GCP Credentials
     id: google-auth
     uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-    if: ${{ contains(inputs.registry, '.pkg.dev') || contains(inputs.registry, 'gcr.io') }}
+    if: ${{ inputs.push == 'true' && (contains(inputs.registry, '.pkg.dev') || contains(inputs.registry, 'gcr.io')) }}
     with:
       token_format: "access_token"
       workload_identity_provider: ${{ inputs.workload-identity-provider }}
@@ -128,7 +128,7 @@ runs:
 
   - name: Login to GCP registry
     uses: docker/login-action@v4
-    if: ${{ contains(inputs.registry, '.pkg.dev') || contains(inputs.registry, 'gcr.io') }}
+    if: ${{ inputs.push == 'true' && (contains(inputs.registry, '.pkg.dev') || contains(inputs.registry, 'gcr.io')) }}
     with:
       registry: ${{ inputs.registry }}
       username: "oauth2accesstoken"


### PR DESCRIPTION
## Summary

In `actions/ci-dockerized-app-build-push/action.yml`, gate the Dockerhub login, GCP auth and GCP registry login steps on `inputs.push == 'true'`.

## Problem

Discovered while migrating `Zilliqa/staking` to `@v4` ([failing run](https://github.com/Zilliqa/staking/actions/runs/24777823019)). The workflow:

```yaml
push: ${{ github.ref_name == github.event.repository.default_branch }}
workload-identity-provider: ${{ secrets.GCP_PRD_GITHUB_WIF }}
```

…was triggered on a feature branch (`frankmeds-patch-1`) where `push` evaluates to `false`. The composite still attempted GCP auth, and the Workload Identity provider's attribute condition (typically `assertion.ref == 'refs/heads/main'`) rejected the OIDC token:

```
unauthorized_client: The given credential is rejected by the attribute condition.
```

This pattern (push-only-on-default-branch + branch-restricted WIF) is common across the Zilliqa stack. Every consumer hits this on every PR / feature-branch push.

## Fix

Three `if:` clauses updated:

| Step | Condition added |
|------|-----------------|
| `Login to Dockerhub` | `inputs.push == 'true' &&` … |
| `Configure GCP Credentials` | `inputs.push == 'true' &&` … |
| `Login to GCP registry` | `inputs.push == 'true' &&` … |

The consumer's existing `push:` expression cascades naturally to the auth step. No new inputs, no branch knowledge baked into the action.

## Edge case

Workflows that pull a **private base image** on a non-pushing branch will now lose auth and fail at `docker pull`. Rare in the Zilliqa stack (images base off public Ubuntu/Alpine/Node). Affected consumers can pre-auth in their workflow before invoking this composite.

## Trivy flow

Unchanged. When `trivy-scan == 'true' && push == 'true'`, auth runs, image is built and loaded, scan runs, the manual final push at the end uses the established session.

## Versioning

Lands on `@v4` directly. After merge, force-bump `v4` and `v4.0.0` tags forward to include this commit (same pattern as PR #85).

## Test plan

- [ ] PR's `update-readme.yaml` job is green
- [ ] After merge + tag bump, re-trigger the failing `Zilliqa/staking` workflow on `frankmeds-patch-1` — auth step should be skipped, build should succeed
- [ ] Spot-check one consumer that does push (e.g., a `cicd-prd.yml` run on main) — auth should still run